### PR TITLE
Changed resolved metadata from name to title (like in toolbox)

### DIFF
--- a/src/NewsBundle/Resources/views/Macro/download.html.twig
+++ b/src/NewsBundle/Resources/views/Macro/download.html.twig
@@ -9,7 +9,7 @@
         {% set download_path = download.getFullPath() %}
         {% set download_size = download.getFileSize('kb', 2) %}
         {% set download_type = download.getFilename()|split('.')|last %}
-        {% set download_name = (download.getMetadata('name')) ? download.getMetadata('name') : title|default('Download'|trans) %}
+        {% set download_name = (download.getMetadata('title')) ? download.getMetadata('title') : title|default('Download'|trans) %}
 
         <li class="item">
             <a href="{{ download_path }}" target="_blank" class="icon-download-{{ download_type }}">

--- a/src/NewsBundle/Resources/views/Macro/download.html.twig
+++ b/src/NewsBundle/Resources/views/Macro/download.html.twig
@@ -3,13 +3,19 @@
     {% if download is not null %}
 
         {% if title == 'filename' %}
-            {% set title = download.getFileName %}
+            {% set title = download.getFileName() %}
         {% endif %}
 
         {% set download_path = download.getFullPath() %}
         {% set download_size = download.getFileSize('kb', 2) %}
         {% set download_type = download.getFilename()|split('.')|last %}
-        {% set download_name = (download.getMetadata('title')) ? download.getMetadata('title') : title|default('Download'|trans) %}
+
+        {% set download_name = title|default('Download'|trans) %}
+        {% if download.getMetadata('name') %}
+            {% set download_name = download.getMetadata('name') %}
+        {% elseif download.getMetadata('title') %}
+            {% set download_name = download.getMetadata('title') %}
+        {% endif %}
 
         <li class="item">
             <a href="{{ download_path }}" target="_blank" class="icon-download-{{ download_type }}">


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | resolves #34 

This PR changes the resolving of the download name in views. With this PR, the download macro now looks for a metadata with the name "title" to make sure that there are no duplicate entries when using this bundle together with the ToolboxBundle.