### PR TITLE
otherElementsExists: allow null for parameter $id

### DIFF
--- a/src/NewsBundle/EventListener/NewsSeoListener.php
+++ b/src/NewsBundle/EventListener/NewsSeoListener.php
@@ -160,7 +160,7 @@ class NewsSeoListener implements EventSubscriberInterface
         return trim($string, '-');
     }
 
-    protected function otherElementsExists(string $objectListingClass, string $locale, string $detailUrl, int $id): bool
+    protected function otherElementsExists(string $objectListingClass, string $locale, string $detailUrl, ?int $id): bool
     {
         /** @var Listing $listing */
         $listing = new $objectListingClass();
@@ -168,7 +168,10 @@ class NewsSeoListener implements EventSubscriberInterface
         $listing->setLocale($locale);
         $listing->setLimit(1);
         $listing->addConditionParam('detailUrl = ?', $detailUrl);
-        $listing->addConditionParam('ooo_id != ?', $id);
+
+        if (!is_null($id)) {
+            $listing->addConditionParam('ooo_id != ?', $id);
+        }
 
         return $listing->getCount() > 0;
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

otherElementsExists: Allow null for parameter $id to prevent error when creating news entries via cli.
error message:
`NewsBundle\EventListener\NewsSeoListener::otherElementsExists(): Argument #4 ($id) must be of type int, null given, called in /var/www/app/vendor/dachcom-digital/news/src/NewsBundle/  
EventListener/NewsSeoListener.php on line 133`