### PR TITLE
fix event constant NEWS_EDITABLE_DIALOG

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,4 +1,8 @@
 # Upgrade Notes
+
+## 3.0.4
+- **[BUGFIX]**: fix event constant `NEWS_EDITABLE_DIALOG`
+
 ## 3.0.3
 - **[BUGFIX]**: fix otherElementsExists method: allow null for parameter `$id` [@pascalmoser](https://github.com/dachcom-digital/pimcore-news/pull/53)
 

--- a/src/NewsBundle/NewsEvents.php
+++ b/src/NewsBundle/NewsEvents.php
@@ -4,6 +4,6 @@ namespace NewsBundle;
 
 class NewsEvents
 {
-   public const NEWS_BRICK_QUERY_BUILD = 'news.brick.query_build';
-   public const NEWS_EDITABLE_DIALOG = 'news.brick.query_build';
+    public const NEWS_BRICK_QUERY_BUILD = 'news.brick.query_build';
+    public const NEWS_EDITABLE_DIALOG = 'news.editable.dialog';
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

fix event constant `NEWS_EDITABLE_DIALOG`
