### PR TITLE
fixed imports for Pimcore\Twig\Extension\Templating\Placeholder\Conta…

### DIFF
--- a/src/NewsBundle/EventListener/MetaDataListener.php
+++ b/src/NewsBundle/EventListener/MetaDataListener.php
@@ -10,6 +10,7 @@ use Pimcore\Twig\Extension\Templating\HeadTitle;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Pimcore\Twig\Extension\Templating\Placeholder\Container;
 
 class MetaDataListener implements EventSubscriberInterface
 {

--- a/src/NewsBundle/Generator/HeadMetaGenerator.php
+++ b/src/NewsBundle/Generator/HeadMetaGenerator.php
@@ -4,7 +4,7 @@ namespace NewsBundle\Generator;
 
 use NewsBundle\Model\EntryInterface;
 use Pimcore\Model\Asset;
-use Pimcore\Templating\Helper\Placeholder\Container;
+use Pimcore\Twig\Extension\Templating\Placeholder\Container;
 use Pimcore\Tool;
 
 class HeadMetaGenerator implements HeadMetaGeneratorInterface


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Fixed tickets | No Ticket created

IMO there were wrong imports of the Container Class in `HeadMetaGenerator.php` and `MetaDataListener.php` (At least with Pimcore Version 10.3.4) as `Pimcore\Templating\Helper\Placeholder\Container` no longer exists and has been moved to `Pimcore\Twig\Extension\Templating\Placeholder\Container`
I Fixed this by adding / fixing the imports in the corresponding files. 
