### PR TITLE
[BUGFIX] Fix exception Type of NewsBundle\Controller\Admin\SettingsController::$translator must not be defined

### DIFF
--- a/src/NewsBundle/Controller/Admin/SettingsController.php
+++ b/src/NewsBundle/Controller/Admin/SettingsController.php
@@ -12,7 +12,6 @@ use Symfony\Component\HttpFoundation\Request;
 
 class SettingsController extends AdminController
 {
-    protected Translator $translator;
     protected EntryTypeManager $entryTypeManager;
 
     public function __construct(Translator $translator, EntryTypeManager $entryTypeManager)


### PR DESCRIPTION


```
Fatal error: Type of NewsBundle\Controller\Admin\SettingsController::$translator must not be defined (as in class Pimcore\Bundle\AdminBundle\Controller\AdminController) in /var/www/html/app/site/vendor/dachcom-digital/news/src/NewsBundle/Controller/Admin/SettingsController.php on line 0
Symfony\Component\ErrorHandler\Error\FatalError {#4131
  #message: "Compile Error: Type of NewsBundle\Controller\Admin\SettingsController::$translator must not be defined (as in class Pimcore\Bundle\AdminBundle\Controller\AdminController)"
  #code: 0
  #file: "./vendor/dachcom-digital/news/src/NewsBundle/Controller/Admin/SettingsController.php"
  #line: 0
  -error: array:4 [
    "type" => 64
    "message" => "Type of NewsBundle\Controller\Admin\SettingsController::$translator must not be defined (as in class Pimcore\Bundle\AdminBundle\Controller\AdminController)"
    "file" => "/var/www/html/app/site/vendor/dachcom-digital/news/src/NewsBundle/Controller/Admin/SettingsController.php"
    "line" => 0
  ]
}
```

| Q             | A
| ------------- | ---
| Bug fix?      | yes/no
| New feature?  | yes/no
| BC breaks?    | no
| Deprecations? | yes/no
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
-->
