### PR TITLE
Refactor HTML class attribute in image templates according to Pimcore 10 requirements

### DIFF
--- a/src/NewsBundle/Resources/views/Detail/Block/Entry/gallery.html.twig
+++ b/src/NewsBundle/Resources/views/Detail/Block/Entry/gallery.html.twig
@@ -7,7 +7,7 @@
         <div class="detail-entry-gallery light-box entry-gallery">
             {% for image in entry.getImages() %}
                 <a href="{{ image.getFullPath() }}" class="item{{ loop.index > 1 ? ' hidden'  : '' }}" data-src="{{ image.getThumbnail('contentImage') }}">
-                    {{ image.getThumbnail(news_thumbnail('gallery_image')).getHtml({'class': 'img-responsive'})|raw }}
+                    {{ image.getThumbnail(news_thumbnail('gallery_image')).getHtml({'imgAttributes': {'class': 'img-responsive'}})|raw }}
                 </a>
             {% endfor %}
         </div>

--- a/src/NewsBundle/Resources/views/Detail/Block/Entry/image.html.twig
+++ b/src/NewsBundle/Resources/views/Detail/Block/Entry/image.html.twig
@@ -6,7 +6,7 @@
 
         <div class="detail-entry-image entry-image">
             <a href="{{ entry.getFullPath() }}" class="item" data-src="{{ entry.getImage().getThumbnail('contentImage') }}">
-                {{ entry.getImage().getThumbnail(news_thumbnail('gallery_image')).getHtml({'class': 'img-responsive'})|raw }}
+                {{ entry.getImage().getThumbnail(news_thumbnail('gallery_image')).getHtml({'imgAttributes': {'class': 'img-responsive'}})|raw }}
             </a>
         </div>
 

--- a/src/NewsBundle/Resources/views/List/Block/Entry/image.html.twig
+++ b/src/NewsBundle/Resources/views/List/Block/Entry/image.html.twig
@@ -6,7 +6,7 @@
 
         <div class="list-entry-image entry-image">
             <a href="{{ news_entry_permalink(news) }}">
-                {{ news.getImage().getThumbnail(news_thumbnail('content_image')).getHtml({'class': 'img-responsive'})|raw }}
+                {{ news.getImage().getThumbnail(news_thumbnail('content_image')).getHtml({'imgAttributes': {'class': 'img-responsive'}})|raw }}
             </a>
         </div>
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

This PR fixes the leftover from Pimcore <=6.x where class names have been applied directly to the options of `thumbnail.getHtml({class: 'my-class'})` method.
Since Pimcore 10 it need to be defined like `thumbnail.getHtml({imgAttributes: {class: 'my-class'}})`